### PR TITLE
Audio Support and Correct Repo Link in course.yaml

### DIFF
--- a/course/course.yaml
+++ b/course/course.yaml
@@ -11,7 +11,7 @@ Course:
     Name: Attribution-ShareAlike 4.0 International
     Short name: CC BY-SA 4.0
     Link: https://creativecommons.org/licenses/by-sa/4.0/legalcode
-  Repository: https://github.com/kantord/LibreLingo-ES-from-EN
+  Repository: https://github.com/vandersdg/LibreLingo-ptBR-from-EN
   Special characters:
     - "á"
     - "Á"

--- a/course/course.yaml
+++ b/course/course.yaml
@@ -32,3 +32,11 @@ Modules:
   - basics/
   - introduction/
   - activities/
+
+Settings:
+  Audio:
+    Enabled: True
+    TTS:
+      - Provider: Polly
+        Voice: Vitoria
+        Engine: standard


### PR DESCRIPTION
LibreLingo has a setting in the course.yaml that when it will be deployed to librelingo.app, it will auto create and put audio into the lessons using Amazon Polly.

I have also changed the repository link to your current repo.