### PR TITLE
Added courses-ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,9 @@
+on: [push]
+
+jobs:
+  verify-course:
+    runs-on: ubuntu-latest
+    name: Verify course
+    steps:
+      - uses: actions/checkout@v2
+      - uses: LibreLingo/course-ci@main

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # LibreLingo-ptBR-from-EN
 
-Brazilian portuguese course for English speakers
+Brazilian Portuguese course for English speakers

--- a/course/activities/skills/continuous.yaml
+++ b/course/activities/skills/continuous.yaml
@@ -93,7 +93,7 @@ Mini-dictionary:
     - singing: cantando
     - song: canção
 
-  Brazilian portuguese:
+  Brazilian Portuguese:
     - cozinhando: cooking
     - janta: cooking
     - fazendo: doing

--- a/course/activities/skills/continuous.yaml
+++ b/course/activities/skills/continuous.yaml
@@ -93,7 +93,7 @@ Mini-dictionary:
     - singing: cantando
     - song: canção
 
-  Portuguese:
+  Brazilian portuguese:
     - cozinhando: cooking
     - janta: cooking
     - fazendo: doing

--- a/course/activities/skills/ser_estar.yaml
+++ b/course/activities/skills/ser_estar.yaml
@@ -94,7 +94,7 @@ Mini-dictionary:
       - alegre
       - contente
 
-  Portuguese:
+  Brazilian Portuguese:
     - estudante: student
     - estou:
       - I am

--- a/course/basics/skills/animals.yaml
+++ b/course/basics/skills/animals.yaml
@@ -112,7 +112,7 @@ Phrases:
     Translation: A duck and a horse
 
 Mini-dictionary:
-  Portuguese:
+  Brazilian Portuguese:
     - um: a/an (masc.)
     - é: is
     - Max: Max (name)

--- a/course/basics/skills/animals.yaml
+++ b/course/basics/skills/animals.yaml
@@ -99,7 +99,7 @@ New words:
       - dog2
       - dog3
 
-Phrasé:
+Phrases:
   - Phrase: É um cavalo
     Translation: It's a horse
 

--- a/course/basics/skills/clothes.yaml
+++ b/course/basics/skills/clothes.yaml
@@ -171,7 +171,7 @@ Mini-dictionary:
       - bebida
     - Maria: Maria (name)
 
-  Portuguese:
+  Brazilian Portuguese:
     - bonito: beautiful
     - O: the
     - os: the

--- a/course/basics/skills/food.yaml
+++ b/course/basics/skills/food.yaml
@@ -65,7 +65,7 @@ New words:
 
 Phrases:
   - Phrase: Bom apetite
-    Translation: Enjoy euur meal
+    Translation: Enjoy your meal
 
   - Phrase: Por favor
     Translation: Please

--- a/course/basics/skills/food.yaml
+++ b/course/basics/skills/food.yaml
@@ -116,7 +116,7 @@ Mini-dictionary:
       - muita
       - muito
 
-  Portuguese:
+  Brazilian Portuguese:
     - por: for
     - favor: favor
     - água: water

--- a/course/basics/skills/nature.yaml
+++ b/course/basics/skills/nature.yaml
@@ -116,4 +116,3 @@ Phrases:
 
   - Phrase: Mar ou montanha?
     Translation: Sea or mountain?
-

--- a/course/basics/skills/plurals.yaml
+++ b/course/basics/skills/plurals.yaml
@@ -148,10 +148,9 @@ Mini-dictionary:
       - vermelha
       - vermelhas
 
-  Portuguese:
+  Brazilian Portuguese:
     - gatos: cats
     - verdes: green
     - bonitas: beautiful
     - aas: the
     - vermelhas: red
-

--- a/course/basics/skills/professions.yaml
+++ b/course/basics/skills/professions.yaml
@@ -102,7 +102,7 @@ Phrases:
     Translation: The singer sings well
 
 Mini-dictionary:
-  Portuguese:
+  Brazilian Portuguese:
     - médico: doctor
     - garçom: waiter
     - garçonete: waiter

--- a/course/basics/skills/verb_plurals.yaml
+++ b/course/basics/skills/verb_plurals.yaml
@@ -59,7 +59,7 @@ Mini-dictionary:
     - horses: cavalos
     - dogs: cães
 
-  Portuguese:
+  Brazilian Portuguese:
     - Nós:
       - we
       - us

--- a/course/basics/skills/verbs.yaml
+++ b/course/basics/skills/verbs.yaml
@@ -43,8 +43,3 @@ Phrases:
 
   - Phrase: O cavalo bebe água
     Translation: The horse drinks water
-
-
-
-
-

--- a/course/course.yaml
+++ b/course/course.yaml
@@ -2,7 +2,7 @@
 
 Course:
   Language:
-    Name: Brazilian portuguese
+    Name: Brazilian Portuguese
     IETF BCP 47: pt-BR
   For speakers of:
     Name: English

--- a/course/introduction/skills/adjectives.yaml
+++ b/course/introduction/skills/adjectives.yaml
@@ -181,7 +181,7 @@ Mini-dictionary:
       - trabalham
       - trabalho
 
-  Portuguese:
+  Brazilian Portuguese:
     - alta: tall
     - alto: tall
     - velho: old

--- a/course/introduction/skills/phrases.yaml
+++ b/course/introduction/skills/phrases.yaml
@@ -88,7 +88,7 @@ Mini-dictionary:
     - afternoon: tarde
     - night: noite
 
-  Portuguese:
+  Brazilian Portuguese:
     - bom: good
     - dias: days
     - chamo: I call

--- a/course/introduction/skills/preferences.yaml
+++ b/course/introduction/skills/preferences.yaml
@@ -94,9 +94,7 @@ Mini-dictionary:
     - don't: "não"
     - doesn't: "não"
 
-  Portuguese:
+  Brazilian Portuguese:
     - uma:
       - a
       - one
-
-

--- a/course/introduction/skills/preferences.yaml
+++ b/course/introduction/skills/preferences.yaml
@@ -42,17 +42,17 @@ New words:
 
 Phrases:
   - Phrase: Você gosta de café?
-   Alternative versions:
+    Alternative versions:
       - Gosta de café?
     Translation: Do you like coffee?
 
   - Phrase: Eu gosto de macarrão
-   Alternative versions:
+    Alternative versions:
       - Gosto de macarrão
     Translation: I like macarrão
 
   - Phrase: Eu gosto de cerveja
-   Alternative versions:
+    Alternative versions:
       - Gosto de cerveja
     Translation: I like beer
 


### PR DESCRIPTION
In the pull request:
- I have added the courses-ci GitHub action, with every push of code the courses-ci GitHub action will check to see if the course can be exported (so that it can be used with LibreLingo)
- I have also changed "Portuguese" to "Brazilian Portuguese" in all the mini-dictionary of every skill because the YAML term for the target language for the mini-dict is defined by the YAML bit 
```
  Language:
    Name: Brazilian Portuguese
```
in the course.yaml
- I fixed a spelling mistake of "euur" to "your" in the food.yaml, courses-ci has the error at the moment: ``` Error while exporting skill "Food": The English word "your" does not have a definition. Please add it to the mini-dictionary.```. I didn't add the mini-dict entry in food.yaml for "your" because I am not a Brazilian Portuguese speaker and don't want to add entries that could possibly be wrong.

Hope this helps!